### PR TITLE
removing "," to fix pedantic warning

### DIFF
--- a/libavutil/avutil.h
+++ b/libavutil/avutil.h
@@ -271,7 +271,7 @@ enum AVPictureType {
     AV_PICTURE_TYPE_S,     ///< S(GMC)-VOP MPEG-4
     AV_PICTURE_TYPE_SI,    ///< Switching Intra
     AV_PICTURE_TYPE_SP,    ///< Switching Predicted
-    AV_PICTURE_TYPE_BI,    ///< BI type
+    AV_PICTURE_TYPE_BI     ///< BI type
 };
 
 /**


### PR DESCRIPTION
This fixes warnings when compiling against ffmpeg with gcc and pedantic warnings enabled. If this is of interest I can fix similar things in other header files as well.